### PR TITLE
Fix `rsync`'s `--exclude` Option

### DIFF
--- a/tests/test_wrapsync2.py
+++ b/tests/test_wrapsync2.py
@@ -9,6 +9,7 @@ from wrapsync2 import (
     build_remote_path,
     build_local_path,
     get_rsync_command,
+    build_exclude_option,
     execute_rsync,
     main
 )
@@ -104,20 +105,29 @@ def should_have_built_local_path(is_parent, expected_result):
 
 @pytest.mark.parametrize('args, expected_result', [
     ({'action': 'push', 'dir_name': 'directory_name', 'options': []},
-     ['rsync', '-aP', '--exclude=\'node_modules\'', '--exclude=\'*.jar\'',
+     ['rsync', '-aP', '--exclude={\'node_modules\', \'*.jar\'}',
       f"{LOCAL_PATH}/directory_name", f"{USERNAME}@{DOMAIN}:{REMOTE_PATH}"]),
     ({'action': 'pull', 'dir_name': 'directory_name', 'options': []},
-     ['rsync', '-aP', '--exclude=\'node_modules\'', '--exclude=\'*.jar\'',
+     ['rsync', '-aP', '--exclude={\'node_modules\', \'*.jar\'}',
       f"{USERNAME}@{DOMAIN}:{REMOTE_PATH}/directory_name", f"{LOCAL_PATH}"]),
     ({'action': 'push', 'dir_name': 'all', 'options': ['--update']},
-     ['rsync', '-aP', '--exclude=\'node_modules\'', '--exclude=\'*.jar\'',
+     ['rsync', '-aP', '--exclude={\'node_modules\', \'*.jar\'}',
       '--update', f"{LOCAL_PATH}", f"{USERNAME}@{DOMAIN}:{REMOTE_PARENT_PATH}"]),
     ({'action': 'pull', 'dir_name': 'all', 'options': ['--delete', '--whatever']},
-     ['rsync', '-aP', '--exclude=\'node_modules\'', '--exclude=\'*.jar\'',
+     ['rsync', '-aP', '--exclude={\'node_modules\', \'*.jar\'}',
       '--delete', '--whatever', f"{USERNAME}@{DOMAIN}:{REMOTE_PATH}", f"{LOCAL_PARENT_PATH}"])
 ])
 def should_have_gotten_rsync_command(args, expected_result):
     assert get_rsync_command(args, CONFIG) == expected_result
+
+
+@pytest.mark.parametrize('excludes, expected_result', [
+    ([], '--exclude={}'),
+    (['node_modules'], '--exclude={\'node_modules\'}'),
+    (['node_modules', '*.jar'], '--exclude={\'node_modules\', \'*.jar\'}')
+])
+def should_have_build_exclude_option(excludes, expected_result):
+    assert build_exclude_option(excludes) == expected_result
 
 
 @pytest.mark.parametrize('exception', [(subprocess.CalledProcessError), (KeyboardInterrupt)])

--- a/wrapsync2.py
+++ b/wrapsync2.py
@@ -124,11 +124,7 @@ def build_remote_path(config, is_parent):
     @param is_parent: whether the path should point to the parent directory of what's in the config
     @return: built remote path
     """
-    remote_path = ''
-    if is_parent:
-        remote_path = dirname(config['remote-path'])
-    else:
-        remote_path = config['remote-path']
+    remote_path = dirname(config['remote-path']) if is_parent else config['remote-path']
     return f"{config['username']}@{config['domain']}:{remote_path}"
 
 
@@ -140,10 +136,7 @@ def build_local_path(config, is_parent):
     @param is_parent: whether the path should point to the parent directory of what's in the config
     @return: built local path
     """
-    if is_parent:
-        return dirname(config['local-path'])
-    else:
-        return config['local-path']
+    return dirname(config['local-path']) if is_parent else config['local-path']
 
 
 def get_rsync_command(args, config):
@@ -157,10 +150,8 @@ def get_rsync_command(args, config):
     # Append flags if, declared
     if config['flags']:
         cmd.append(f"-{config['flags']}")
-    # Append exclusions, if declared
-    if config['exclude']:
-        for exclude in config['exclude']:
-            cmd.append(f"--exclude='{exclude}'")
+    # Append exclusions
+    cmd.append(build_exclude_option(config['exclude']))
     # Append all remaining command-line arguments as rsync options
     for option in args['options']:
         cmd.append(option)
@@ -169,6 +160,20 @@ def get_rsync_command(args, config):
     cmd.append(paths['from'])
     cmd.append(paths['to'])
     return cmd
+
+
+def build_exclude_option(excludes):
+    """
+    Builds and returns the `--exclude` rsync option.
+    @param excludes: list of patterns to exclude
+    @return: `--exclude` option
+    """
+    exclude_option = '--exclude={'
+    for i, exclude in enumerate(excludes):
+        exclude_option += ', ' if i > 0 else ''
+        exclude_option += f"'{exclude}'"
+    exclude_option += '}'
+    return exclude_option
 
 
 def execute_rsync(cmd):


### PR DESCRIPTION
There's a big difference between the current assumption and what's correct. Can't use multiple `--exclude` options with the equal sign. Wither use white space, or combine the patterns in curly braces.

From
<https://linuxize.com/post/how-to-exclude-files-and-directories-with-rsync>:

> Exclude Multiple Files or Directories
> 
> To exclude multiple files or directories simply specify multiple --exclude options:
> 
> > rsync -a --exclude 'file1.txt' --exclude 'dir1/\*' --exclude 'dir2' src_directory/ dst_directory/
> 
> If you prefer to use a single --exclude option you can list the files and directories you want to exclude in curly braces {} separated by a comma as shown below:
> 
> > rsync -a --exclude={'file1.txt','dir1/\*','dir2'} src_directory/ dst_directory/