### PR TITLE
Fix The `--exclude` Option by Splitting The Statement and Removing Quotes

### DIFF
--- a/tests/test_wrapsync2.py
+++ b/tests/test_wrapsync2.py
@@ -9,7 +9,6 @@ from wrapsync2 import (
     build_remote_path,
     build_local_path,
     get_rsync_command,
-    build_exclude_option,
     execute_rsync,
     main
 )
@@ -105,29 +104,20 @@ def should_have_built_local_path(is_parent, expected_result):
 
 @pytest.mark.parametrize('args, expected_result', [
     ({'action': 'push', 'dir_name': 'directory_name', 'options': []},
-     ['rsync', '-aP', '--exclude={\'node_modules\',\'*.jar\'}',
+     ['rsync', '-aP', '--exclude=node_modules', '--exclude=*.jar',
       f"{LOCAL_PATH}/directory_name", f"{USERNAME}@{DOMAIN}:{REMOTE_PATH}"]),
     ({'action': 'pull', 'dir_name': 'directory_name', 'options': []},
-     ['rsync', '-aP', '--exclude={\'node_modules\',\'*.jar\'}',
+     ['rsync', '-aP', '--exclude=node_modules', '--exclude=*.jar',
       f"{USERNAME}@{DOMAIN}:{REMOTE_PATH}/directory_name", f"{LOCAL_PATH}"]),
     ({'action': 'push', 'dir_name': 'all', 'options': ['--update']},
-     ['rsync', '-aP', '--exclude={\'node_modules\',\'*.jar\'}',
+     ['rsync', '-aP', '--exclude=node_modules', '--exclude=*.jar',
       '--update', f"{LOCAL_PATH}", f"{USERNAME}@{DOMAIN}:{REMOTE_PARENT_PATH}"]),
     ({'action': 'pull', 'dir_name': 'all', 'options': ['--delete', '--whatever']},
-     ['rsync', '-aP', '--exclude={\'node_modules\',\'*.jar\'}',
+     ['rsync', '-aP', '--exclude=node_modules', '--exclude=*.jar',
       '--delete', '--whatever', f"{USERNAME}@{DOMAIN}:{REMOTE_PATH}", f"{LOCAL_PARENT_PATH}"])
 ])
 def should_have_gotten_rsync_command(args, expected_result):
     assert get_rsync_command(args, CONFIG) == expected_result
-
-
-@pytest.mark.parametrize('excludes, expected_result', [
-    ([], '--exclude={}'),
-    (['node_modules'], '--exclude={\'node_modules\'}'),
-    (['node_modules', '*.jar'], '--exclude={\'node_modules\',\'*.jar\'}')
-])
-def should_have_build_exclude_option(excludes, expected_result):
-    assert build_exclude_option(excludes) == expected_result
 
 
 @pytest.mark.parametrize('exception', [(subprocess.CalledProcessError), (KeyboardInterrupt)])

--- a/wrapsync2.py
+++ b/wrapsync2.py
@@ -151,7 +151,8 @@ def get_rsync_command(args, config):
     if config['flags']:
         cmd.append(f"-{config['flags']}")
     # Append exclusions
-    cmd.append(build_exclude_option(config['exclude']))
+    for exclude in config['exclude']:
+        cmd.append(f"--exclude={exclude}")
     # Append all remaining command-line arguments as rsync options
     for option in args['options']:
         cmd.append(option)
@@ -160,20 +161,6 @@ def get_rsync_command(args, config):
     cmd.append(paths['from'])
     cmd.append(paths['to'])
     return cmd
-
-
-def build_exclude_option(excludes):
-    """
-    Builds and returns the `--exclude` rsync option.
-    @param excludes: list of patterns to exclude
-    @return: `--exclude` option
-    """
-    exclude_option = '--exclude={'
-    for i, exclude in enumerate(excludes):
-        exclude_option += ',' if i > 0 else ''
-        exclude_option += f"'{exclude}'"
-    exclude_option += '}'
-    return exclude_option
 
 
 def execute_rsync(cmd):


### PR DESCRIPTION
#### Context
When running the built command inside of `subprocess`, it doesn't recognise the details of the `--exclude` option. It works fine in `Zsh` when copy-pasted, but not via `subprocess`. The brace expansion didn't work either. Therefore, the only way that seems to work is to append multiple `--exclude` options with values like so:

```console
rsync --exclude=*.jar --exclude=war source dest
```

I linked the thread in the previous fix attempt but turns out I missed some key details from the comments:
https://askubuntu.com/a/525513

#### Manual testing

Use the `--dry-run --verbose` options to see whether the excludes from the config take effect:

```console
ws pull Foo --update --dry-run --verbose
```

Then, copy-paste the executed command and compare stdout's.